### PR TITLE
Added custom markers and legend for geojson shortcodes

### DIFF
--- a/shortcodes/class.geojson-shortcode.php
+++ b/shortcodes/class.geojson-shortcode.php
@@ -81,7 +81,7 @@ class Leaflet_Geojson_Shortcode extends Leaflet_Shortcode {
                         pointToLayer: function(feature, latlng) {
                             return feature.properties.iconUrl ? new L.Marker(latlng, {icon: L.icon({
                                 iconUrl: feature.properties.iconUrl,
-                                iconSize: [40, 40], // size of the icon
+                                iconSize: feature.properties.iconSize ? feature.properties.iconSize : [25, 41], // size of the icon
                             })}) : new L.Marker(latlng);
                         }
                     }),
@@ -115,26 +115,28 @@ class Leaflet_Geojson_Shortcode extends Leaflet_Shortcode {
                 function onEachFeature (feature, layer) {
                     var props = feature.properties || {},
                         text = popup_property && props[ popup_property ] || template(popup_text, feature.properties),
-                        species = feature.properties.name,
+                        featureName = feature.properties.name,
                         iconUrl = feature.properties.iconUrl;
                     if (text) {
                         layer.bindPopup( text );
                     }
-                    // create the legend entities for the species names, assumes the filename pattern is *-[iconColor].png
-                    legendVals[species] = iconUrl.slice(iconUrl.lastIndexOf("-")+1, iconUrl.length-4);
+                    if (iconUrl) {
+                        // create the legend entities for the feature names, assumes the filename pattern is *-[iconColor].*
+                        legendVals[featureName] = iconUrl.slice(iconUrl.lastIndexOf("-")+1, iconUrl.lastIndexOf("."));
+                    }
                 }
                 layer.on('ready', function () {
-                    if('<?php echo $legend; ?>') {
+                    if('<?php echo $legend; ?>' && JSON.stringify(legendVals) !== JSON.stringify({})) {
                         // add a legend for the icons
                         var legend = L.control({position: 'bottomright'});
                         legend.onAdd = function (previous_map) {
                             var div = L.DomUtil.create('div', 'info legend');
 
-                           // loop through our legend items and generate a label with a colored square for each species
-                           for (var key in legendVals) {
-                               div.innerHTML += '<i style="background: ' + legendVals[key] + '"></i>' + key + '<br>';
-                           }
-                           return div;
+                            // loop through our legend items and generate a label with a colored square for each distinct feature name
+                            for (var key in legendVals) {
+                                div.innerHTML += '<i style="background: ' + legendVals[key] + '"></i>' + key + '<br>';
+                            }
+                            return div;
                        };
                        legend.addTo(previous_map);
                     }

--- a/shortcodes/class.geojson-shortcode.php
+++ b/shortcodes/class.geojson-shortcode.php
@@ -122,14 +122,14 @@ class Leaflet_Geojson_Shortcode extends Leaflet_Shortcode {
                     }
                     if (iconUrl) {
                         // create the legend entities for the feature names, assumes the filename pattern is *-[iconColor].*
-                        legendVals[featureName] = iconUrl.slice(iconUrl.lastIndexOf("-")+1, iconUrl.lastIndexOf("."));
+                        legendVals[featureName] = iconUrl.slice(iconUrl.lastIndexOf("-") + 1, iconUrl.lastIndexOf("."));
                     }
                 }
                 layer.on('ready', function () {
                     if('<?php echo $legend; ?>' && JSON.stringify(legendVals) !== JSON.stringify({})) {
                         // add a legend for the icons
                         var legend = L.control({position: 'bottomright'});
-                        legend.onAdd = function (previous_map) {
+                        legend.onAdd = function (previousMap) {
                             var div = L.DomUtil.create('div', 'info legend');
 
                             // loop through our legend items and generate a label with a colored square for each distinct feature name

--- a/shortcodes/class.geojson-shortcode.php
+++ b/shortcodes/class.geojson-shortcode.php
@@ -62,7 +62,6 @@ class Leaflet_Geojson_Shortcode extends Leaflet_Shortcode {
         ?>
         <script>
             WPLeafletMapPlugin.add(function () {
-                var legendVals = new Object();
                 var previous_map = WPLeafletMapPlugin.getCurrentMap(),
                     src = '<?php echo $src; ?>',
                     default_style = <?php echo $style_json; ?>,
@@ -87,7 +86,8 @@ class Leaflet_Geojson_Shortcode extends Leaflet_Shortcode {
                     }),
                     fitbounds = <?php echo $fitbounds; ?>,
                     popup_text = WPLeafletMapPlugin.unescape('<?php echo $popup_text; ?>'),
-                    popup_property = '<?php echo $popup_property; ?>';
+                    popup_property = '<?php echo $popup_property; ?>',
+                    legendVals = {};
                 if (fitbounds) {
                     layer.on('ready', function () {
                         this.map.fitBounds( this.getBounds() );

--- a/shortcodes/class.map-shortcode.php
+++ b/shortcodes/class.map-shortcode.php
@@ -52,6 +52,7 @@ class Leaflet_Map_Shortcode extends Leaflet_Shortcode {
 		$atts['scrollwheel'] = array_key_exists('scrollwheel', $atts) ? $scrollwheel : $settings->get('scroll_wheel_zoom');
 		$atts['doubleclickzoom'] = array_key_exists('doubleclickzoom', $atts) ? $doubleclickzoom : $settings->get('double_click_zoom');
 		$atts['fit_markers'] = array_key_exists('fit_markers', $atts) ? $fit_markers : $settings->get('fit_markers');
+		$atts['legend'] = array_key_exists('legend', $atts) ? $legend : false;
 
 		/* allow percent, but add px for ints */
 		$atts['height'] .= is_numeric($atts['height']) ? 'px' : '';


### PR DESCRIPTION
The legend assumes the marker filename pattern is *-[iconColor].png and creates a coloured square for each icon.

The legend toggle is a shortcode attribute for legend=1. Omitting it will default to false.